### PR TITLE
Feature/specify message and signal

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+# Vehicle Edge Platform - Development Container
+# Ubuntu 24.04 with all build dependencies
+
+FROM ubuntu:24.04
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    cmake \
+    libgoogle-glog-dev \
+    nlohmann-json3-dev \
+    libyaml-cpp-dev \
+    can-utils \
+    libprotobuf32t64 \
+    libgrpc++1.51t64 \
+    libgflags2.2 \
+    libyaml-cpp0.8 \
+    liblua5.4-0 \
+    libpaho-mqtt1.3 \
+    libpaho-mqttpp3-1 \
+    libmosquitto1 \
+    netcat-openbsd \
+    libgtest-dev \
+    libgmock-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /workspaces/vehicle-edge-platform

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+    "name": "Vehicle Edge Platform",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools",
+                "vadimcn.vscode-lldb"
+            ],
+            "settings": {
+                "cmake.buildDirectory": "${workspaceFolder}/build"
+            }
+        }
+    },
+    "mounts": [
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,readonly"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build
 .idea
-
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -173,14 +173,14 @@ while (running) {
 ```yaml
 # Direct CAN mapping with Lua filter
 - signal: Vehicle.Speed
-  source: {type: dbc, name: DI_vehicleSpeed}
+  source: {type: dbc, name: DriveTrain.DI_vehicleSpeed}
   datatype: float
   transform:
     code: "lowpass(x, 0.3)"
 
 # Direct CAN mapping specifying message and signal, returning data as-is
-- signal: Vehicle.Speed
-  source: {type: dbc, message: FuelConsumption name: TotalUsed}
+- signal: Vehicle.FuelUsed
+  source: {type: dbc, name: FuelConsumption.TotalUsed}
   datatype: float
   transform:
     code: "x"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ while (running) {
   transform:
     code: "lowpass(x, 0.3)"
 
+# Direct CAN mapping specifying message and signal, returning data as-is
+- signal: Vehicle.Speed
+  source: {type: dbc, message: FuelConsumption name: TotalUsed}
+  datatype: float
+  transform:
+    code: "x"
+
 # Derived signal (dependencies trigger processing)
 - signal: Vehicle.Acceleration.Longitudinal
   depends_on: [Vehicle.Speed]
@@ -352,6 +359,3 @@ Tests cover: DAG initialization, topological sort, derived signals, structs, inv
 ## License
 
 Apache License 2.0
-
-
-

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Build script for libVSSDAG
 # Kept in root directory for convenience
 
@@ -20,5 +22,3 @@ echo "  cd build && ctest"
 echo ""
 echo "To run the example:"
 echo "  ./build/examples/can_transformer/can-transformer <dbc_file> <mapping_yaml> <can_interface>"
-
-

--- a/examples/battery_management/battery_cells_mapping.yaml
+++ b/examples/battery_management/battery_cells_mapping.yaml
@@ -6,84 +6,84 @@ mappings:
   - signal: cell1_voltage
     source:
       type: dbc
-      name: Cell1_Voltage
+      name: BMS_CellVoltages_1_3.Cell1_Voltage
     transform:
       code: "x"  # Already in V from DBC
       
   - signal: cell2_voltage
     source:
       type: dbc
-      name: Cell2_Voltage
+      name: BMS_CellVoltages_1_3.Cell2_Voltage
     transform:
       code: "x"
       
   - signal: cell3_voltage
     source:
       type: dbc
-      name: Cell3_Voltage
+      name: BMS_CellVoltages_1_3.Cell3_Voltage
     transform:
       code: "x"
       
   - signal: cell4_voltage
     source:
       type: dbc
-      name: Cell4_Voltage
+      name: BMS_CellVoltages_4_6.Cell4_Voltage
     transform:
       code: "x"
       
   - signal: cell5_voltage
     source:
       type: dbc
-      name: Cell5_Voltage
+      name: BMS_CellVoltages_4_6.Cell5_Voltage
     transform:
       code: "x"
       
   - signal: cell6_voltage
     source:
       type: dbc
-      name: Cell6_Voltage
+      name: BMS_CellVoltages_4_6.Cell6_Voltage
     transform:
       code: "x"
       
   - signal: cell7_voltage
     source:
       type: dbc
-      name: Cell7_Voltage
+      name: BMS_CellVoltages_7_9.Cell7_Voltage
     transform:
       code: "x"
       
   - signal: cell8_voltage
     source:
       type: dbc
-      name: Cell8_Voltage
+      name: BMS_CellVoltages_7_9.Cell8_Voltage
     transform:
       code: "x"
       
   - signal: cell9_voltage
     source:
       type: dbc
-      name: Cell9_Voltage
+      name: BMS_CellVoltages_7_9.Cell9_Voltage
     transform:
       code: "x"
       
   - signal: cell10_voltage
     source:
       type: dbc
-      name: Cell10_Voltage
+      name: BMS_CellVoltages_10_12.Cell10_Voltage
     transform:
       code: "x"
       
   - signal: cell11_voltage
     source:
       type: dbc
-      name: Cell11_Voltage
+      name: BMS_CellVoltages_10_12.Cell11_Voltage
     transform:
       code: "x"
       
   - signal: cell12_voltage
     source:
       type: dbc
-      name: Cell12_Voltage
+      name: BMS_CellVoltages_10_12.Cell12_Voltage
     transform:
       code: "x"
       
@@ -91,7 +91,7 @@ mappings:
   - signal: min_cell_voltage
     source:
       type: dbc
-      name: MinCellVoltage
+      name: BMS_CellStatistics.MinCellVoltage
     vss_path: Vehicle.Powertrain.TractionBattery.Cell.MinVoltage
     datatype: float
     interval_ms: 1000
@@ -101,7 +101,7 @@ mappings:
   - signal: max_cell_voltage
     source:
       type: dbc
-      name: MaxCellVoltage
+      name: BMS_CellStatistics.MaxCellVoltage
     vss_path: Vehicle.Powertrain.TractionBattery.Cell.MaxVoltage
     datatype: float
     interval_ms: 1000

--- a/examples/invalid_signal_handling.yaml
+++ b/examples/invalid_signal_handling.yaml
@@ -6,7 +6,7 @@ mappings:
   - signal: cabin_temperature
     source:
       type: dbc
-      name: HVAC_CabinTemp  # DBC signal with range [-40, 85]
+      name: HVAC_Status.HVAC_CabinTemp  # DBC signal with range [-40, 85]
     datatype: float
     transform:
       code: |

--- a/examples/tesla_model3/model3_mappings_dag.yaml
+++ b/examples/tesla_model3/model3_mappings_dag.yaml
@@ -6,7 +6,7 @@ mappings:
   - signal: Vehicle.Speed
     source:
       type: dbc
-      name: DI_vehicleSpeed
+      name: ID257DIspeed.DI_vehicleSpeed
     datatype: float
     interval_ms: 50
     transform:
@@ -15,7 +15,7 @@ mappings:
   - signal: Vehicle.Chassis.Brake.IsPressed
     source:
       type: dbc
-      name: DI_brakePedalState
+      name: ID118DriveSystemStatus.DI_brakePedalState
     datatype: boolean
     interval_ms: 50
     transform:
@@ -26,7 +26,7 @@ mappings:
   - signal: Vehicle.Chassis.Accelerator.Position
     source:
       type: dbc
-      name: DI_accelPedalPos
+      name: ID118DriveSystemStatus.DI_accelPedalPos
     datatype: float
     interval_ms: 50
     transform:
@@ -35,7 +35,7 @@ mappings:
   - signal: Vehicle.ADAS.ABS.IsActive
     source:
       type: dbc
-      name: ESP_absBrakeEvent
+      name: ID145ESP_status.ESP_absBrakeEvent
     datatype: boolean
     interval_ms: 100
     transform:
@@ -48,7 +48,7 @@ mappings:
   - signal: Vehicle.Chassis.SteeringWheel.Angle
     source:
       type: dbc
-      name: SteeringAngle129
+      name: ID129SteeringAngle.SteeringAngle129
     datatype: float
     interval_ms: 50
     transform:
@@ -57,7 +57,7 @@ mappings:
   - signal: Vehicle.Powertrain.Transmission.CurrentGear
     source:
       type: dbc
-      name: DI_gear
+      name: ID118DriveSystemStatus.DI_gear
     datatype: string
     interval_ms: 200
     transform:
@@ -290,7 +290,7 @@ mappings:
   - signal: Vehicle.Body.Lights.DirectionIndicator.Right.IsSignaling
     source:
       type: dbc
-      name: VCRIGHT_turnSignalStatus
+      name: ID3E3VCRIGHT_lightStatus.VCRIGHT_turnSignalStatus
     datatype: boolean
     interval_ms: 100
     transform:
@@ -303,7 +303,7 @@ mappings:
   - signal: Vehicle.Body.Lights.DirectionIndicator.Left.IsSignaling
     source:
       type: dbc
-      name: VCLEFT_turnSignalStatus
+      name: ID3E2VCLEFT_lightStatus.VCLEFT_turnSignalStatus
     datatype: boolean
     interval_ms: 100
     transform:
@@ -317,7 +317,7 @@ mappings:
   - signal: Vehicle.Body.Lights.Backup.IsOn
     source:
       type: dbc
-      name: VCRIGHT_reverseLightStatus
+      name: ID3E3VCRIGHT_lightStatus.VCRIGHT_reverseLightStatus
     datatype: boolean
     interval_ms: 100
     transform:
@@ -331,7 +331,7 @@ mappings:
   - signal: Vehicle.Powertrain.Battery.StateOfCharge.Current
     source:
       type: dbc
-      name: SOCUI292
+      name: ID292BMS_SOC.SOCUI292
     datatype: float
     interval_ms: 1000
     transform:
@@ -340,7 +340,7 @@ mappings:
   - signal: Vehicle.Powertrain.Battery.Voltage
     source:
       type: dbc
-      name: BattVoltage132
+      name: ID132HVBattAmpVolt.BattVoltage132
     datatype: float
     interval_ms: 1000
     transform:
@@ -349,7 +349,7 @@ mappings:
   - signal: Vehicle.Powertrain.Battery.Current
     source:
       type: dbc
-      name: SmoothBattCurrent132
+      name: ID132HVBattAmpVolt.SmoothBattCurrent132
     datatype: float
     interval_ms: 1000
     transform:
@@ -359,7 +359,7 @@ mappings:
   - signal: Vehicle.Powertrain.ElectricMotor.Torque
     source:
       type: dbc
-      name: DI_torqueActual
+      name: ID266DITorque.DI_torqueActual
     datatype: float
     interval_ms: 100
     transform:
@@ -368,7 +368,7 @@ mappings:
   - signal: Vehicle.Powertrain.ElectricMotor.Speed
     source:
       type: dbc
-      name: DI_motorRPM
+      name: ID266DITorque.DI_motorRPM
     datatype: float
     interval_ms: 100
     transform:
@@ -378,7 +378,7 @@ mappings:
   - signal: Vehicle.Cabin.Door.Row1.DriverSide.IsOpen
     source:
       type: dbc
-      name: VCLEFT_frontDoorState
+      name: ID122VCLEFT_doorStatus2.VCLEFT_frontDoorState
     datatype: boolean
     interval_ms: 500
     transform:
@@ -391,7 +391,7 @@ mappings:
   - signal: Vehicle.Cabin.Door.Row2.DriverSide.IsOpen
     source:
       type: dbc
-      name: VCLEFT_rearDoorState
+      name: ID122VCLEFT_doorStatus2.VCLEFT_rearDoorState
     datatype: boolean
     interval_ms: 500
     transform:
@@ -405,7 +405,7 @@ mappings:
   - signal: Vehicle.Body.Trunk.Rear.IsOpen
     source:
       type: dbc
-      name: VCRIGHT_trunkLatchStatus
+      name: ID103VCRIGHT_doorStatus.VCRIGHT_trunkLatchStatus
     datatype: boolean
     interval_ms: 500
     transform:
@@ -421,7 +421,7 @@ mappings:
   - signal: Vehicle.Cabin.HVAC.Station.Row1.Driver.Temperature
     source:
       type: dbc
-      name: HVAC_targetTempLeft
+      name: ID3C8HVAC_status.HVAC_targetTempLeft
     datatype: float
     interval_ms: 1000
     transform:
@@ -430,7 +430,7 @@ mappings:
   - signal: Vehicle.Cabin.HVAC.Station.Row1.Passenger.Temperature
     source:
       type: dbc
-      name: HVAC_targetTempRight
+      name: ID3C8HVAC_status.HVAC_targetTempRight
     datatype: float
     interval_ms: 1000
     transform:

--- a/include/vssdag/can/can_source.h
+++ b/include/vssdag/can/can_source.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <thread>
 #include <atomic>
-#include <unordered_set>
 #include <unordered_map>
 #include <moodycamel/concurrentqueue.h>
 #include "vssdag/signal_source.h"
@@ -57,14 +56,10 @@ private:
     // Mappings from YAML
     std::unordered_map<std::string, SignalMapping> mappings_;
     
-    // DBC signal names we need (extracted from mappings where source.type == "dbc")
-    std::vector<std::pair<std::string, std::string>> dbc_signal_names_;
-    
-    // Map from DBC message and signal name to our signal name
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> dbc_to_signal_name_;
-    
-    // CAN message IDs we need to process (derived from dbc_signal_names via DBC)
-    std::unordered_set<uint32_t> required_can_ids_;
+    // Map from CAN message ID to (DBC signal name → VSS signal name)
+    // Outer key: CAN ID for fast frame filtering
+    // Inner key: DBC signal name within that message
+    std::unordered_map<uint32_t, std::unordered_map<std::string, std::string>> can_id_signal_map_;
     
     // Reader thread
     std::unique_ptr<std::thread> reader_thread_;

--- a/include/vssdag/can/can_source.h
+++ b/include/vssdag/can/can_source.h
@@ -58,10 +58,10 @@ private:
     std::unordered_map<std::string, SignalMapping> mappings_;
     
     // DBC signal names we need (extracted from mappings where source.type == "dbc")
-    std::vector<std::string> dbc_signal_names_;
+    std::vector<std::pair<std::string, std::string>> dbc_signal_names_;
     
-    // Map from DBC signal name to our signal name
-    std::unordered_map<std::string, std::string> dbc_to_signal_name_;
+    // Map from DBC message and signal name to our signal name
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> dbc_to_signal_name_;
     
     // CAN message IDs we need to process (derived from dbc_signal_names via DBC)
     std::unordered_set<uint32_t> required_can_ids_;

--- a/include/vssdag/can/dbc_parser.h
+++ b/include/vssdag/can/dbc_parser.h
@@ -35,13 +35,7 @@ public:
     // Get all signals with their enum mappings
     std::unordered_map<std::string, EnumMap> get_all_signal_enums() const;
     
-    // Get the CAN message definition that contains a specific signal
-    const dbcppp::IMessage* get_message_for_signal(const std::string& signal_name) const;
-
-    // Get the CAN message ID that contains a specific signal
-    std::optional<uint32_t> get_message_id_for_signal(const std::string& signal_name) const;
-    
-    // Get the CAN message ID that contains a specific signal in a specific message
+    // Get the CAN message ID for a signal within a specific message
     std::optional<uint32_t> get_message_id_for_signal(const std::string& message_name, const std::string& signal_name) const;
     
     // Convert an enum value to its string representation (returns empty optional if not found)
@@ -83,8 +77,10 @@ private:
         }
     };
     
-    // Single cache for all signal information
-    std::unordered_map<std::string, SignalInfo> signal_info_;
+    // Signal information keyed by CAN message ID, then signal name.
+    // Two-level map ensures same-named signals in different messages
+    // get their own correct bit patterns for status detection.
+    std::unordered_map<uint32_t, std::unordered_map<std::string, SignalInfo>> signal_info_;
 };
 
 } // namespace vssdag

--- a/include/vssdag/can/dbc_parser.h
+++ b/include/vssdag/can/dbc_parser.h
@@ -35,8 +35,14 @@ public:
     // Get all signals with their enum mappings
     std::unordered_map<std::string, EnumMap> get_all_signal_enums() const;
     
+    // Get the CAN message definition that contains a specific signal
+    const dbcppp::IMessage* get_message_for_signal(const std::string& signal_name) const;
+
     // Get the CAN message ID that contains a specific signal
     std::optional<uint32_t> get_message_id_for_signal(const std::string& signal_name) const;
+    
+    // Get the CAN message ID that contains a specific signal in a specific message
+    std::optional<uint32_t> get_message_id_for_signal(const std::string& message_name, const std::string& signal_name) const;
     
     // Convert an enum value to its string representation (returns empty optional if not found)
     std::optional<std::string> get_enum_string(const std::string& signal_name, int64_t value) const;

--- a/include/vssdag/can/dbc_types.h
+++ b/include/vssdag/can/dbc_types.h
@@ -121,7 +121,8 @@ struct DBCDecodedValue {
 
 // Raw signal update from DBC decoding (before name mapping)
 struct DBCSignalUpdate {
-    std::string_view dbc_signal_name;  // Reference to DBC signal name (no allocation)
+    std::string_view dbc_message_name;  // Reference to DBC message name (no allocation)
+    std::string_view dbc_signal_name;   // Reference to DBC signal name (no allocation)
     vss::types::Value value;
     vss::types::SignalQuality status = vss::types::SignalQuality::VALID;  // Signal validity status
     bool has_enums = false;

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,51 @@
+# Build and Install concurrentqueue
+cd /tmp
+git clone --depth 1 https://github.com/cameron314/concurrentqueue.git
+cd concurrentqueue
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      ..
+cmake --install .
+
+# Build and Install dbcppp
+cd /tmp
+git clone --depth 1 https://github.com/xR3b0rn/dbcppp.git
+cd dbcppp
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -Dbuild_kcd=OFF \
+      -Dbuild_tools=OFF \
+      -Dbuild_tests=OFF \
+      -Dbuild_examples=OFF \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      ..
+make -j$(nproc)
+make install
+ldconfig
+
+# Build and Install Open1722 (AVTP support)
+cd /tmp
+git clone --depth 1 https://github.com/COVESA/Open1722.git
+cd Open1722
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      ..
+make -j$(nproc)
+make install
+ldconfig
+
+# Build and Install libvss-types
+cd /tmp
+git clone --depth 1 https://github.com/tr-sdv-sandbox/libvss-types.git
+cd libvss-types
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DVSS_TYPES_BUILD_TESTS=OFF \
+      -DVSS_TYPES_BUILD_EXAMPLES=OFF \
+      -DCMAKE_INSTALL_PREFIX=/usr/local \
+      ..
+make -j$(nproc)
+make install
+ldconfig

--- a/src/can/can_source.cpp
+++ b/src/can/can_source.cpp
@@ -26,48 +26,41 @@ bool CANSignalSource::initialize() {
         return false;
     }
     
-    // Extract DBC signals from mappings (where source.type == "dbc")
-    for (const auto& [signal_name, mapping] : mappings_) {
-        if (mapping.source.type == "dbc") {
-            auto dot_pos = mapping.source.name.find('.');
-            if (dot_pos != std::string::npos) {
-                std::string message_name = mapping.source.name.substr(0, dot_pos);
-                std::string name = mapping.source.name.substr(dot_pos + 1);
-                dbc_signal_names_.emplace_back(name, message_name);
-                dbc_to_signal_name_[message_name][name] = signal_name;
-            } else {
-                // For signals without message prefix, we need to find the message
-                auto msg = dbc_parser_->get_message_for_signal(mapping.source.name);
-                if (msg == nullptr) {
-                    LOG(WARNING) << "DBC signal " << mapping.source.name << " not found in DBC file";
-                    continue;
-                }
+    // Extract DBC signals from mappings and resolve to CAN IDs.
+    // Source name must be in "Message.Signal" format.
+    size_t signal_count = 0;
+    for (const auto& [vss_name, mapping] : mappings_) {
+        if (mapping.source.type != "dbc") continue;
 
-                dbc_signal_names_.emplace_back(mapping.source.name, msg->Name());
-                dbc_to_signal_name_[msg->Name()][mapping.source.name] = signal_name;
-            }
+        auto dot_pos = mapping.source.name.find('.');
+        if (dot_pos == std::string::npos) {
+            LOG(ERROR) << "DBC source name must be in 'Message.Signal' format, got: "
+                       << mapping.source.name;
+            return false;
         }
-    }
-    
-    // Build set of required CAN IDs from DBC signal names
-    for (const auto& [dbc_signal_name, message_name] : dbc_signal_names_) {
-        auto can_id = dbc_parser_->get_message_id_for_signal(message_name, dbc_signal_name);
-        if (can_id.has_value()) {
-            required_can_ids_.insert(can_id.value());
-            VLOG(1) << "DBC signal " << dbc_signal_name << " is in CAN message ID: 0x" 
-                    << std::hex << can_id.value();
-        } else {
-            LOG(WARNING) << "DBC signal " << dbc_signal_name << " not found in DBC file";
+
+        std::string message_name = mapping.source.name.substr(0, dot_pos);
+        std::string dbc_signal = mapping.source.name.substr(dot_pos + 1);
+
+        auto can_id = dbc_parser_->get_message_id_for_signal(message_name, dbc_signal);
+        if (!can_id.has_value()) {
+            LOG(WARNING) << "DBC signal " << mapping.source.name << " not found in DBC file";
+            continue;
         }
+
+        can_id_signal_map_[can_id.value()][dbc_signal] = vss_name;
+        ++signal_count;
+        VLOG(1) << "DBC signal " << mapping.source.name << " is in CAN message ID: 0x"
+                << std::hex << can_id.value();
     }
-    
-    if (required_can_ids_.empty()) {
+
+    if (can_id_signal_map_.empty()) {
         LOG(WARNING) << "No valid CAN message IDs found for requested signals";
-        return true; // Not an error, just no signals to monitor
+        return true;
     }
-    
-    LOG(INFO) << "CANSignalSource monitoring " << required_can_ids_.size()
-              << " CAN message IDs for " << dbc_signal_names_.size() << " DBC signals";
+
+    LOG(INFO) << "CANSignalSource monitoring " << can_id_signal_map_.size()
+              << " CAN message IDs for " << signal_count << " DBC signals";
 
     // Create CAN reader based on transport type
     switch (transport_) {
@@ -100,38 +93,31 @@ bool CANSignalSource::initialize() {
 }
 
 void CANSignalSource::handle_can_frame(const CANFrame& frame) {
-    // Quick check if we care about this CAN ID
-    if (required_can_ids_.find(frame.id) == required_can_ids_.end()) {
+    // Fast lookup by CAN ID — no work if we don't care about this message
+    auto msg_it = can_id_signal_map_.find(frame.id);
+    if (msg_it == can_id_signal_map_.end()) {
         return;
     }
 
     VLOG(3) << "Processing CAN frame ID: 0x" << std::hex << frame.id;
-    
-    // Decode the frame directly to signal updates
+
     auto dbc_updates = dbc_parser_->decode_message_as_updates(
         frame.id, frame.data.data(), frame.data.size());
-    
-    // Convert to SignalUpdate and enqueue (only the signals we care about)
+
     auto timestamp = std::chrono::steady_clock::now();
     for (const auto& dbc_update : dbc_updates) {
-        // Check if this DBC signal is one we need
-        // Note: In C++17 we need to construct a string for the lookup
-        auto msg_it = dbc_to_signal_name_.find(std::string(dbc_update.dbc_message_name));
-        if (msg_it != dbc_to_signal_name_.end()) {
-            auto sig_it = msg_it->second.find(std::string(dbc_update.dbc_signal_name));
-            if (sig_it != msg_it->second.end()) {
-                // Use our signal name (not the DBC name) in the update
-                SignalUpdate update{sig_it->second, dbc_update.value, timestamp, dbc_update.status};
-                signal_queue_.enqueue(std::move(update));
-                
-                // Log with type and status info
-                const char* status_str = (dbc_update.status == vss::types::SignalQuality::VALID) ? "valid" :
-                                        (dbc_update.status == vss::types::SignalQuality::INVALID) ? "invalid" : "not_available";
-                std::string value_str = VSSTypeHelper::to_string(dbc_update.value);
-                VLOG(3) << "Enqueued message: " << msg_it->first << "signal: " << sig_it->second << " (DBC: " << dbc_update.dbc_signal_name
-                        << ") = " << value_str << " (" << status_str << ")";
-            }
-        }
+        // Lookup by DBC signal name within this CAN ID
+        auto sig_it = msg_it->second.find(std::string(dbc_update.dbc_signal_name));
+        if (sig_it == msg_it->second.end()) continue;
+
+        SignalUpdate update{sig_it->second, dbc_update.value, timestamp, dbc_update.status};
+        signal_queue_.enqueue(std::move(update));
+
+        const char* status_str = (dbc_update.status == vss::types::SignalQuality::VALID) ? "valid" :
+                                (dbc_update.status == vss::types::SignalQuality::INVALID) ? "invalid" : "not_available";
+        VLOG(3) << "Enqueued signal: " << sig_it->second << " (DBC: "
+                << dbc_update.dbc_message_name << "." << dbc_update.dbc_signal_name
+                << ") = " << VSSTypeHelper::to_string(dbc_update.value) << " (" << status_str << ")";
     }
 }
 

--- a/src/can/can_source.cpp
+++ b/src/can/can_source.cpp
@@ -29,14 +29,29 @@ bool CANSignalSource::initialize() {
     // Extract DBC signals from mappings (where source.type == "dbc")
     for (const auto& [signal_name, mapping] : mappings_) {
         if (mapping.source.type == "dbc") {
-            dbc_signal_names_.push_back(mapping.source.name);
-            dbc_to_signal_name_[mapping.source.name] = signal_name;
+            auto dot_pos = mapping.source.name.find('.');
+            if (dot_pos != std::string::npos) {
+                std::string message_name = mapping.source.name.substr(0, dot_pos);
+                std::string name = mapping.source.name.substr(dot_pos + 1);
+                dbc_signal_names_.emplace_back(name, message_name);
+                dbc_to_signal_name_[message_name][name] = signal_name;
+            } else {
+                // For signals without message prefix, we need to find the message
+                auto msg = dbc_parser_->get_message_for_signal(mapping.source.name);
+                if (msg == nullptr) {
+                    LOG(WARNING) << "DBC signal " << mapping.source.name << " not found in DBC file";
+                    continue;
+                }
+
+                dbc_signal_names_.emplace_back(mapping.source.name, msg->Name());
+                dbc_to_signal_name_[msg->Name()][mapping.source.name] = signal_name;
+            }
         }
     }
     
     // Build set of required CAN IDs from DBC signal names
-    for (const auto& dbc_signal_name : dbc_signal_names_) {
-        auto can_id = dbc_parser_->get_message_id_for_signal(dbc_signal_name);
+    for (const auto& [dbc_signal_name, message_name] : dbc_signal_names_) {
+        auto can_id = dbc_parser_->get_message_id_for_signal(message_name, dbc_signal_name);
         if (can_id.has_value()) {
             required_can_ids_.insert(can_id.value());
             VLOG(1) << "DBC signal " << dbc_signal_name << " is in CAN message ID: 0x" 
@@ -101,18 +116,21 @@ void CANSignalSource::handle_can_frame(const CANFrame& frame) {
     for (const auto& dbc_update : dbc_updates) {
         // Check if this DBC signal is one we need
         // Note: In C++17 we need to construct a string for the lookup
-        auto it = dbc_to_signal_name_.find(std::string(dbc_update.dbc_signal_name));
-        if (it != dbc_to_signal_name_.end()) {
-            // Use our signal name (not the DBC name) in the update
-            SignalUpdate update{it->second, dbc_update.value, timestamp, dbc_update.status};
-            signal_queue_.enqueue(std::move(update));
-            
-            // Log with type and status info
-            const char* status_str = (dbc_update.status == vss::types::SignalQuality::VALID) ? "valid" :
-                                    (dbc_update.status == vss::types::SignalQuality::INVALID) ? "invalid" : "not_available";
-            std::string value_str = VSSTypeHelper::to_string(dbc_update.value);
-            VLOG(3) << "Enqueued signal: " << it->second << " (DBC: " << dbc_update.dbc_signal_name
-                    << ") = " << value_str << " (" << status_str << ")";
+        auto msg_it = dbc_to_signal_name_.find(std::string(dbc_update.dbc_message_name));
+        if (msg_it != dbc_to_signal_name_.end()) {
+            auto sig_it = msg_it->second.find(std::string(dbc_update.dbc_signal_name));
+            if (sig_it != msg_it->second.end()) {
+                // Use our signal name (not the DBC name) in the update
+                SignalUpdate update{sig_it->second, dbc_update.value, timestamp, dbc_update.status};
+                signal_queue_.enqueue(std::move(update));
+                
+                // Log with type and status info
+                const char* status_str = (dbc_update.status == vss::types::SignalQuality::VALID) ? "valid" :
+                                        (dbc_update.status == vss::types::SignalQuality::INVALID) ? "invalid" : "not_available";
+                std::string value_str = VSSTypeHelper::to_string(dbc_update.value);
+                VLOG(3) << "Enqueued message: " << msg_it->first << "signal: " << sig_it->second << " (DBC: " << dbc_update.dbc_signal_name
+                        << ") = " << value_str << " (" << status_str << ")";
+            }
         }
     }
 }

--- a/src/can/dbc_parser.cpp
+++ b/src/can/dbc_parser.cpp
@@ -163,6 +163,7 @@ std::vector<DBCSignalUpdate> DBCParser::decode_message_as_updates(uint32_t can_i
                     
                     DBCSignalUpdate update;
                     update.dbc_signal_name = std::string_view(sig.Name());
+                    update.dbc_message_name = std::string_view(msg.Name());
                     
                     // Look up pre-calculated signal info
                     auto info_it = signal_info_.find(sig.Name());
@@ -252,6 +253,22 @@ std::unordered_map<std::string, DBCParser::EnumMap> DBCParser::get_all_signal_en
     return all_enums;
 }
 
+const dbcppp::IMessage* DBCParser::get_message_for_signal(const std::string& signal_name) const {
+    if (!network_) {
+        return nullptr;
+    }
+    
+    for (const auto& msg : network_->Messages()) {
+        for (const auto& sig : msg.Signals()) {
+            if (sig.Name() == signal_name) {
+                return &msg;
+            }
+        }
+    }
+    
+    return nullptr;
+}
+
 std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& signal_name) const {
     if (!network_) {
         return std::nullopt;
@@ -264,6 +281,26 @@ std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& 
                 const uint32_t CAN_EFF_MASK = 0x1FFFFFFFU;
                 return msg.Id() & CAN_EFF_MASK;
             }
+        }
+    }
+    
+    return std::nullopt;
+}
+
+std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& message_name, const std::string& signal_name) const {
+    if (!network_) {
+        return std::nullopt;
+    }
+    
+    for (const auto& msg : network_->Messages()) {
+        if (msg.Name() == message_name) {
+            for (const auto& sig : msg.Signals()) {
+                if (sig.Name() == signal_name) {
+                    const uint32_t CAN_EFF_MASK = 0x1FFFFFFFU;
+                    return msg.Id() & CAN_EFF_MASK;
+                }
+            }
+            break;
         }
     }
     

--- a/src/can/dbc_parser.cpp
+++ b/src/can/dbc_parser.cpp
@@ -27,51 +27,55 @@ bool DBCParser::parse() {
         
         // Extract signal information and pre-calculate invalid/NA patterns
         signal_info_.clear();
+        const uint32_t CAN_EFF_MASK = 0x1FFFFFFFU;
+        size_t total_signals = 0;
         for (const auto& msg : network_->Messages()) {
+            uint32_t msg_id = msg.Id() & CAN_EFF_MASK;
             for (const auto& sig : msg.Signals()) {
                 SignalInfo info;
-                
+
                 // Extract enum mappings
                 for (const auto& value_desc : sig.ValueEncodingDescriptions()) {
                     info.enums[value_desc.Description()] = value_desc.Value();
                     info.reverse_enums[value_desc.Value()] = value_desc.Description();
-                    VLOG(2) << "Signal " << sig.Name() << " enum: " 
+                    VLOG(2) << "Signal " << sig.Name() << " enum: "
                             << value_desc.Value() << " = " << value_desc.Description();
                 }
-                
+
                 // Pre-calculate invalid/NA patterns
                 uint64_t bit_size = sig.BitSize();
                 uint64_t max_possible_raw = (bit_size >= 64) ? UINT64_MAX : ((1ULL << bit_size) - 1);
-                
+
                 info.invalid_raw_value = max_possible_raw;
                 info.na_raw_value = max_possible_raw - 1;
                 info.min_physical = sig.Minimum();
                 info.max_physical = sig.Maximum();
-                
+
                 // Check if invalid pattern is usable (outside valid range)
                 double physical_invalid = sig.RawToPhys(info.invalid_raw_value);
-                info.can_use_invalid_pattern = (physical_invalid < info.min_physical || 
+                info.can_use_invalid_pattern = (physical_invalid < info.min_physical ||
                                                physical_invalid > info.max_physical);
-                
+
                 // Check if NA pattern is usable (outside valid range)
                 double physical_na = sig.RawToPhys(info.na_raw_value);
-                info.can_use_na_pattern = (physical_na < info.min_physical || 
+                info.can_use_na_pattern = (physical_na < info.min_physical ||
                                           physical_na > info.max_physical);
-                
-                VLOG(2) << "Signal " << sig.Name() << ": bits=" << bit_size 
-                        << ", invalid=" << std::hex << info.invalid_raw_value 
+
+                VLOG(2) << "Signal " << msg.Name() << "." << sig.Name() << ": bits=" << bit_size
+                        << ", invalid=" << std::hex << info.invalid_raw_value
                         << " (usable=" << info.can_use_invalid_pattern << ")"
-                        << ", na=" << info.na_raw_value 
+                        << ", na=" << info.na_raw_value
                         << " (usable=" << info.can_use_na_pattern << ")"
-                        << ", range=[" << std::dec << info.min_physical 
+                        << ", range=[" << std::dec << info.min_physical
                         << ", " << info.max_physical << "]";
-                
-                signal_info_[sig.Name()] = std::move(info);
+
+                signal_info_[msg_id][sig.Name()] = std::move(info);
+                ++total_signals;
             }
         }
-        
-        LOG(INFO) << "Successfully parsed DBC file: " << dbc_file_ 
-                  << " with " << signal_info_.size() << " signals";
+
+        LOG(INFO) << "Successfully parsed DBC file: " << dbc_file_
+                  << " with " << total_signals << " signals";
         return true;
     } catch (const std::exception& e) {
         LOG(ERROR) << "Exception parsing DBC file: " << e.what();
@@ -93,43 +97,42 @@ std::unordered_map<std::string, DBCDecodedValue> DBCParser::decode_message(uint3
 
     for (const auto& msg : network_->Messages()) {
         if ((msg.Id() & CAN_EFF_MASK) == can_id_masked) {
+            auto msg_info_it = signal_info_.find(can_id_masked);
             for (const auto& sig : msg.Signals()) {
                 try {
                     uint64_t raw_value = sig.Decode(data);
                     double physical_value = sig.RawToPhys(raw_value);
-                    
+
                     DBCDecodedValue decoded_value;
-                    
-                    // Look up pre-calculated signal info
-                    auto info_it = signal_info_.find(sig.Name());
-                    if (info_it != signal_info_.end()) {
-                        const auto& info = info_it->second;
-                        decoded_value.has_enums = !info.enums.empty();
-                        decoded_value.status = info.check_status(raw_value, physical_value);
-                    } else {
-                        // Shouldn't happen if parse() was successful
-                        decoded_value.has_enums = false;
-                        decoded_value.status = vss::types::SignalQuality::VALID;
+
+                    // Look up pre-calculated signal info by message ID + signal name
+                    if (msg_info_it != signal_info_.end()) {
+                        auto info_it = msg_info_it->second.find(sig.Name());
+                        if (info_it != msg_info_it->second.end()) {
+                            const auto& info = info_it->second;
+                            decoded_value.has_enums = !info.enums.empty();
+                            decoded_value.status = info.check_status(raw_value, physical_value);
+                        }
                     }
-                    
+
                     // Determine type based on signal properties
                     // If the signal has scaling (factor != 1.0 or offset != 0), treat as double
                     // Otherwise check if it can be represented as an integer
                     if ((sig.Factor() == 1.0 && sig.Offset() == 0.0) &&
-                            std::floor(physical_value) == physical_value && 
+                            std::floor(physical_value) == physical_value &&
                             physical_value >= std::numeric_limits<int64_t>::min() &&
                             physical_value <= std::numeric_limits<int64_t>::max()) {
                             // It's an integer signal with no scaling
                             decoded_value.value = static_cast<int64_t>(physical_value);
-                            VLOG(2) << "Decoded signal " << sig.Name() << " = " << static_cast<int64_t>(physical_value) 
+                            VLOG(2) << "Decoded signal " << sig.Name() << " = " << static_cast<int64_t>(physical_value)
                                     << " (int, status=" << static_cast<int>(decoded_value.status) << ")";
                     } else {
                         // It's a float (has scaling or is a fractional value)
                         decoded_value.value = physical_value;
-                        VLOG(2) << "Decoded signal " << sig.Name() << " = " << physical_value 
+                        VLOG(2) << "Decoded signal " << sig.Name() << " = " << physical_value
                                 << " (float, status=" << static_cast<int>(decoded_value.status) << ")";
                     }
-                    
+
                     decoded_signals[sig.Name()] = std::move(decoded_value);
                 } catch (const std::exception& e) {
                     LOG(WARNING) << "Failed to decode signal " << sig.Name() << ": " << e.what();
@@ -156,45 +159,44 @@ std::vector<DBCSignalUpdate> DBCParser::decode_message_as_updates(uint32_t can_i
 
     for (const auto& msg : network_->Messages()) {
         if ((msg.Id() & CAN_EFF_MASK) == can_id_masked) {
+            auto msg_info_it = signal_info_.find(can_id_masked);
             for (const auto& sig : msg.Signals()) {
                 try {
                     uint64_t raw_value = sig.Decode(data);
                     double physical_value = sig.RawToPhys(raw_value);
-                    
+
                     DBCSignalUpdate update;
                     update.dbc_signal_name = std::string_view(sig.Name());
                     update.dbc_message_name = std::string_view(msg.Name());
-                    
-                    // Look up pre-calculated signal info
-                    auto info_it = signal_info_.find(sig.Name());
-                    if (info_it != signal_info_.end()) {
-                        const auto& info = info_it->second;
-                        update.has_enums = !info.enums.empty();
-                        update.status = info.check_status(raw_value, physical_value);
-                    } else {
-                        // Shouldn't happen if parse() was successful
-                        update.has_enums = false;
-                        update.status = vss::types::SignalQuality::VALID;
+
+                    // Look up pre-calculated signal info by message ID + signal name
+                    if (msg_info_it != signal_info_.end()) {
+                        auto info_it = msg_info_it->second.find(sig.Name());
+                        if (info_it != msg_info_it->second.end()) {
+                            const auto& info = info_it->second;
+                            update.has_enums = !info.enums.empty();
+                            update.status = info.check_status(raw_value, physical_value);
+                        }
                     }
-                    
+
                     // Determine type based on signal properties
                     // If the signal has scaling (factor != 1.0 or offset != 0), treat as double
                     // Otherwise check if it can be represented as an integer
                     if ((sig.Factor() == 1.0 && sig.Offset() == 0.0) &&
-                            std::floor(physical_value) == physical_value && 
+                            std::floor(physical_value) == physical_value &&
                             physical_value >= std::numeric_limits<int64_t>::min() &&
                             physical_value <= std::numeric_limits<int64_t>::max()) {
                             // It's an integer signal with no scaling
                             update.value = static_cast<int64_t>(physical_value);
-                            VLOG(2) << "Decoded signal " << sig.Name() << " = " << static_cast<int64_t>(physical_value) 
+                            VLOG(2) << "Decoded signal " << sig.Name() << " = " << static_cast<int64_t>(physical_value)
                                     << " (int, status=" << static_cast<int>(update.status) << ")";
                     } else {
                         // It's a float (has scaling or is a fractional value)
                         update.value = physical_value;
-                        VLOG(2) << "Decoded signal " << sig.Name() << " = " << physical_value 
+                        VLOG(2) << "Decoded signal " << sig.Name() << " = " << physical_value
                                 << " (float, status=" << static_cast<int>(update.status) << ")";
                     }
-                    
+
                     updates.push_back(std::move(update));
                 } catch (const std::exception& e) {
                     LOG(WARNING) << "Failed to decode signal " << sig.Name() << ": " << e.what();
@@ -236,55 +238,25 @@ std::vector<std::string> DBCParser::get_signal_names(uint32_t can_id) const {
 }
 
 DBCParser::EnumMap DBCParser::get_signal_enums(const std::string& signal_name) const {
-    auto it = signal_info_.find(signal_name);
-    if (it != signal_info_.end()) {
-        return it->second.enums;
+    for (const auto& [msg_id, signals] : signal_info_) {
+        auto it = signals.find(signal_name);
+        if (it != signals.end()) {
+            return it->second.enums;
+        }
     }
     return {};
 }
 
 std::unordered_map<std::string, DBCParser::EnumMap> DBCParser::get_all_signal_enums() const {
     std::unordered_map<std::string, EnumMap> all_enums;
-    for (const auto& [name, info] : signal_info_) {
-        if (!info.enums.empty()) {
-            all_enums[name] = info.enums;
+    for (const auto& [msg_id, signals] : signal_info_) {
+        for (const auto& [name, info] : signals) {
+            if (!info.enums.empty()) {
+                all_enums[name] = info.enums;
+            }
         }
     }
     return all_enums;
-}
-
-const dbcppp::IMessage* DBCParser::get_message_for_signal(const std::string& signal_name) const {
-    if (!network_) {
-        return nullptr;
-    }
-    
-    for (const auto& msg : network_->Messages()) {
-        for (const auto& sig : msg.Signals()) {
-            if (sig.Name() == signal_name) {
-                return &msg;
-            }
-        }
-    }
-    
-    return nullptr;
-}
-
-std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& signal_name) const {
-    if (!network_) {
-        return std::nullopt;
-    }
-    
-    for (const auto& msg : network_->Messages()) {
-        for (const auto& sig : msg.Signals()) {
-            if (sig.Name() == signal_name) {
-                // Return the ID with extended flag stripped
-                const uint32_t CAN_EFF_MASK = 0x1FFFFFFFU;
-                return msg.Id() & CAN_EFF_MASK;
-            }
-        }
-    }
-    
-    return std::nullopt;
 }
 
 std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& message_name, const std::string& signal_name) const {
@@ -308,17 +280,17 @@ std::optional<uint32_t> DBCParser::get_message_id_for_signal(const std::string& 
 }
 
 std::optional<std::string> DBCParser::get_enum_string(const std::string& signal_name, int64_t value) const {
-    auto it = signal_info_.find(signal_name);
-    if (it == signal_info_.end()) {
-        return std::nullopt;
+    for (const auto& [msg_id, signals] : signal_info_) {
+        auto it = signals.find(signal_name);
+        if (it != signals.end()) {
+            auto enum_it = it->second.reverse_enums.find(value);
+            if (enum_it != it->second.reverse_enums.end()) {
+                return enum_it->second;
+            }
+            return std::nullopt;
+        }
     }
-    
-    auto enum_it = it->second.reverse_enums.find(value);
-    if (enum_it == it->second.reverse_enums.end()) {
-        return std::nullopt;
-    }
-    
-    return enum_it->second;
+    return std::nullopt;
 }
 
 } // namespace vssdag

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -89,3 +89,15 @@ target_link_libraries(test_candump_parser
     GTest::gtest_main
 )
 gtest_discover_tests(test_candump_parser)
+
+# Test for CANSignalSource
+add_executable(test_can_source
+    test_can_source.cpp
+)
+target_link_libraries(test_can_source
+    vssdag
+    GTest::gtest
+    GTest::gtest_main
+    # GTest::gmock
+)
+gtest_discover_tests(test_can_source)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -98,6 +98,5 @@ target_link_libraries(test_can_source
     vssdag
     GTest::gtest
     GTest::gtest_main
-    # GTest::gmock
 )
 gtest_discover_tests(test_can_source)

--- a/tests/unit/test_can_source.cpp
+++ b/tests/unit/test_can_source.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include "vssdag/can/can_source.h"
+#include "vssdag/mapping_types.h"
+#include <fstream>
+
+using namespace vssdag;
+
+class CANSourceTest : public ::testing::Test {
+protected:
+    std::string test_dbc_file;
+    
+    void SetUp() override {
+        test_dbc_file = "test_can_source.dbc";
+        CreateTestDBCFile();
+    }
+    
+    void TearDown() override {
+        std::remove(test_dbc_file.c_str());
+    }
+    
+    void CreateTestDBCFile() {
+        std::ofstream file(test_dbc_file);
+        file << "VERSION \"\"\n\n";
+        file << "BS_:\n\n";
+        file << "BU_: ECU1 ECU2\n\n";
+        
+        // Message with ID 0x100 (256)
+        file << "BO_ 256 TestMessage1: 8 ECU1\n";
+        file << " SG_ Speed : 0|16@1+ (0.1,0) [0|6553.5] \"km/h\" ECU2\n";
+        file << " SG_ Temperature : 16|8@1- (1,-40) [-40|215] \"degC\" ECU2\n";
+        file << "\n";
+        
+        // Message with ID 0x200 (512) 
+        file << "BO_ 512 TestMessage2: 4 ECU2\n";
+        file << " SG_ Voltage : 0|12@1+ (0.01,0) [0|40.95] \"V\" ECU1\n";
+        file << "\n";
+        
+        // Message with same signal name in different message
+        file << "BO_ 768 TestMessage3: 4 ECU1\n";
+        file << " SG_ Speed : 0|16@1+ (0.1,0) [0|6553.5] \"km/h\" ECU2\n";
+        file << "\n";
+        
+        file.close();
+    }
+    
+    std::unordered_map<std::string, SignalMapping> CreateTestMappings() {
+        std::unordered_map<std::string, SignalMapping> mappings;
+        
+        // Direct signal mapping
+        SignalMapping speed_mapping;
+        speed_mapping.datatype = ValueType::FLOAT;
+        speed_mapping.transform = DirectMapping{};
+        speed_mapping.source.type = "dbc";
+        speed_mapping.source.name = "Speed";
+        mappings["Vehicle.Speed"] = speed_mapping;
+        
+        // Signal with message prefix
+        SignalMapping voltage_mapping;
+        voltage_mapping.datatype = ValueType::FLOAT;
+        voltage_mapping.transform = DirectMapping{};
+        voltage_mapping.source.type = "dbc";
+        voltage_mapping.source.name = "TestMessage2.Voltage";
+        mappings["Vehicle.Voltage"] = voltage_mapping;
+        
+        // Same signal name in specific message
+        SignalMapping speed2_mapping;
+        speed2_mapping.datatype = ValueType::FLOAT;
+        speed2_mapping.transform = DirectMapping{};
+        speed2_mapping.source.type = "dbc";
+        speed2_mapping.source.name = "TestMessage3.Speed";
+        mappings["Vehicle.Speed2"] = speed2_mapping;
+        
+        return mappings;
+    }
+};
+
+// Test initialization with mixed signal formats
+TEST_F(CANSourceTest, InitializeWithMixedSignalFormats) {
+    auto mappings = CreateTestMappings();
+    
+    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
+    
+    // Initialize should succeed (even if CAN interface fails, DBC parsing should work)
+    // We expect this to fail at CAN interface opening, but DBC parsing should succeed
+    bool result = source.initialize();
+    
+    // The result depends on whether vcan0 exists, but we can check exported signals
+    auto exported = source.get_exported_signals();
+    EXPECT_EQ(exported.size(), 3);
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Vehicle.Speed"), exported.end());
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Vehicle.Voltage"), exported.end());
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Vehicle.Speed2"), exported.end());
+}
+
+// Test that signal names are correctly parsed and stored
+TEST_F(CANSourceTest, SignalNameParsing) {
+    auto mappings = CreateTestMappings();
+    
+    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
+    
+    // This will fail at CAN interface opening but should parse DBC and mappings
+    source.initialize();
+    
+    // Check that exported signals match what we configured
+    auto exported = source.get_exported_signals();
+    std::sort(exported.begin(), exported.end());
+    
+    std::vector<std::string> expected = {"Vehicle.Speed", "Vehicle.Speed2", "Vehicle.Voltage"};
+    std::sort(expected.begin(), expected.end());
+    
+    EXPECT_EQ(exported, expected);
+}
+
+// Test with non-existent DBC file
+TEST_F(CANSourceTest, NonExistentDBCFile) {
+    auto mappings = CreateTestMappings();
+    
+    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", "non_existent.dbc", mappings);
+    
+    EXPECT_FALSE(source.initialize());
+}
+
+// Test with empty mappings
+TEST_F(CANSourceTest, EmptyMappings) {
+    std::unordered_map<std::string, SignalMapping> empty_mappings;
+    
+    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, empty_mappings);
+    
+    // Should succeed with empty mappings (no signals to monitor)
+    // Will fail at CAN interface opening, but that's expected
+    source.initialize();
+    
+    auto exported = source.get_exported_signals();
+    EXPECT_EQ(exported.size(), 0);
+}
+
+// Test signal mapping with message prefix parsing
+TEST_F(CANSourceTest, MessagePrefixParsing) {
+    std::unordered_map<std::string, SignalMapping> mappings;
+    
+    // Test various formats
+    SignalMapping mapping1;
+    mapping1.datatype = ValueType::FLOAT;
+    mapping1.transform = DirectMapping{};
+    mapping1.source.type = "dbc";
+    mapping1.source.name = "TestMessage1.Speed";  // With prefix
+    mappings["Signal1"] = mapping1;
+    
+    SignalMapping mapping2;
+    mapping2.datatype = ValueType::FLOAT;
+    mapping2.transform = DirectMapping{};
+    mapping2.source.type = "dbc";
+    mapping2.source.name = "Voltage";  // Without prefix
+    mappings["Signal2"] = mapping2;
+    
+    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
+    source.initialize();
+    
+    auto exported = source.get_exported_signals();
+    EXPECT_EQ(exported.size(), 2);
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Signal1"), exported.end());
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Signal2"), exported.end());
+}

--- a/tests/unit/test_can_source.cpp
+++ b/tests/unit/test_can_source.cpp
@@ -8,83 +8,79 @@ using namespace vssdag;
 class CANSourceTest : public ::testing::Test {
 protected:
     std::string test_dbc_file;
-    
+
     void SetUp() override {
         test_dbc_file = "test_can_source.dbc";
         CreateTestDBCFile();
     }
-    
+
     void TearDown() override {
         std::remove(test_dbc_file.c_str());
     }
-    
+
     void CreateTestDBCFile() {
         std::ofstream file(test_dbc_file);
         file << "VERSION \"\"\n\n";
         file << "BS_:\n\n";
         file << "BU_: ECU1 ECU2\n\n";
-        
+
         // Message with ID 0x100 (256)
         file << "BO_ 256 TestMessage1: 8 ECU1\n";
         file << " SG_ Speed : 0|16@1+ (0.1,0) [0|6553.5] \"km/h\" ECU2\n";
         file << " SG_ Temperature : 16|8@1- (1,-40) [-40|215] \"degC\" ECU2\n";
         file << "\n";
-        
-        // Message with ID 0x200 (512) 
+
+        // Message with ID 0x200 (512)
         file << "BO_ 512 TestMessage2: 4 ECU2\n";
         file << " SG_ Voltage : 0|12@1+ (0.01,0) [0|40.95] \"V\" ECU1\n";
         file << "\n";
-        
+
         // Message with same signal name in different message
         file << "BO_ 768 TestMessage3: 4 ECU1\n";
         file << " SG_ Speed : 0|16@1+ (0.1,0) [0|6553.5] \"km/h\" ECU2\n";
         file << "\n";
-        
+
         file.close();
     }
-    
+
     std::unordered_map<std::string, SignalMapping> CreateTestMappings() {
         std::unordered_map<std::string, SignalMapping> mappings;
-        
-        // Direct signal mapping
+
         SignalMapping speed_mapping;
         speed_mapping.datatype = ValueType::FLOAT;
         speed_mapping.transform = DirectMapping{};
         speed_mapping.source.type = "dbc";
-        speed_mapping.source.name = "Speed";
+        speed_mapping.source.name = "TestMessage1.Speed";
         mappings["Vehicle.Speed"] = speed_mapping;
-        
-        // Signal with message prefix
+
         SignalMapping voltage_mapping;
         voltage_mapping.datatype = ValueType::FLOAT;
         voltage_mapping.transform = DirectMapping{};
         voltage_mapping.source.type = "dbc";
         voltage_mapping.source.name = "TestMessage2.Voltage";
         mappings["Vehicle.Voltage"] = voltage_mapping;
-        
-        // Same signal name in specific message
+
+        // Same signal name disambiguated by message
         SignalMapping speed2_mapping;
         speed2_mapping.datatype = ValueType::FLOAT;
         speed2_mapping.transform = DirectMapping{};
         speed2_mapping.source.type = "dbc";
         speed2_mapping.source.name = "TestMessage3.Speed";
         mappings["Vehicle.Speed2"] = speed2_mapping;
-        
+
         return mappings;
     }
 };
 
-// Test initialization with mixed signal formats
-TEST_F(CANSourceTest, InitializeWithMixedSignalFormats) {
+// Test that DBC parsing and signal extraction works with qualified names.
+// Uses a non-existent CAN interface so initialize() fails at socket open
+// (after DBC parsing succeeds), avoiding a blocking reader thread.
+TEST_F(CANSourceTest, InitializeWithQualifiedSignals) {
     auto mappings = CreateTestMappings();
-    
-    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
-    
-    // Initialize should succeed (even if CAN interface fails, DBC parsing should work)
-    // We expect this to fail at CAN interface opening, but DBC parsing should succeed
-    bool result = source.initialize();
-    
-    // The result depends on whether vcan0 exists, but we can check exported signals
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", test_dbc_file, mappings);
+    source.initialize();
+
     auto exported = source.get_exported_signals();
     EXPECT_EQ(exported.size(), 3);
     EXPECT_NE(std::find(exported.begin(), exported.end(), "Vehicle.Speed"), exported.end());
@@ -92,72 +88,81 @@ TEST_F(CANSourceTest, InitializeWithMixedSignalFormats) {
     EXPECT_NE(std::find(exported.begin(), exported.end(), "Vehicle.Speed2"), exported.end());
 }
 
-// Test that signal names are correctly parsed and stored
-TEST_F(CANSourceTest, SignalNameParsing) {
+// Test that bare signal names (without message prefix) are rejected
+TEST_F(CANSourceTest, BareSignalNameRejected) {
+    std::unordered_map<std::string, SignalMapping> mappings;
+
+    SignalMapping mapping;
+    mapping.datatype = ValueType::FLOAT;
+    mapping.transform = DirectMapping{};
+    mapping.source.type = "dbc";
+    mapping.source.name = "Speed";  // Missing message prefix
+    mappings["Vehicle.Speed"] = mapping;
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", test_dbc_file, mappings);
+
+    EXPECT_FALSE(source.initialize());
+}
+
+// Test that exported signals match configuration
+TEST_F(CANSourceTest, ExportedSignalsMatchConfig) {
     auto mappings = CreateTestMappings();
-    
-    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
-    
-    // This will fail at CAN interface opening but should parse DBC and mappings
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", test_dbc_file, mappings);
     source.initialize();
-    
-    // Check that exported signals match what we configured
+
     auto exported = source.get_exported_signals();
     std::sort(exported.begin(), exported.end());
-    
+
     std::vector<std::string> expected = {"Vehicle.Speed", "Vehicle.Speed2", "Vehicle.Voltage"};
     std::sort(expected.begin(), expected.end());
-    
+
     EXPECT_EQ(exported, expected);
 }
 
 // Test with non-existent DBC file
 TEST_F(CANSourceTest, NonExistentDBCFile) {
     auto mappings = CreateTestMappings();
-    
-    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", "non_existent.dbc", mappings);
-    
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", "non_existent.dbc", mappings);
+
     EXPECT_FALSE(source.initialize());
 }
 
 // Test with empty mappings
 TEST_F(CANSourceTest, EmptyMappings) {
     std::unordered_map<std::string, SignalMapping> empty_mappings;
-    
-    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, empty_mappings);
-    
-    // Should succeed with empty mappings (no signals to monitor)
-    // Will fail at CAN interface opening, but that's expected
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", test_dbc_file, empty_mappings);
     source.initialize();
-    
+
     auto exported = source.get_exported_signals();
     EXPECT_EQ(exported.size(), 0);
 }
 
-// Test signal mapping with message prefix parsing
-TEST_F(CANSourceTest, MessagePrefixParsing) {
+// Test disambiguating same signal name across messages
+TEST_F(CANSourceTest, DisambiguateSameSignalName) {
     std::unordered_map<std::string, SignalMapping> mappings;
-    
-    // Test various formats
+
     SignalMapping mapping1;
     mapping1.datatype = ValueType::FLOAT;
     mapping1.transform = DirectMapping{};
     mapping1.source.type = "dbc";
-    mapping1.source.name = "TestMessage1.Speed";  // With prefix
-    mappings["Signal1"] = mapping1;
-    
+    mapping1.source.name = "TestMessage1.Speed";
+    mappings["Speed.From.Message1"] = mapping1;
+
     SignalMapping mapping2;
     mapping2.datatype = ValueType::FLOAT;
     mapping2.transform = DirectMapping{};
     mapping2.source.type = "dbc";
-    mapping2.source.name = "Voltage";  // Without prefix
-    mappings["Signal2"] = mapping2;
-    
-    CANSignalSource source(CANTransport::SOCKETCAN, "vcan0", test_dbc_file, mappings);
+    mapping2.source.name = "TestMessage3.Speed";
+    mappings["Speed.From.Message3"] = mapping2;
+
+    CANSignalSource source(CANTransport::SOCKETCAN, "noexist0", test_dbc_file, mappings);
     source.initialize();
-    
+
     auto exported = source.get_exported_signals();
     EXPECT_EQ(exported.size(), 2);
-    EXPECT_NE(std::find(exported.begin(), exported.end(), "Signal1"), exported.end());
-    EXPECT_NE(std::find(exported.begin(), exported.end(), "Signal2"), exported.end());
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Speed.From.Message1"), exported.end());
+    EXPECT_NE(std::find(exported.begin(), exported.end(), "Speed.From.Message3"), exported.end());
 }

--- a/tests/unit/test_dbc_parser.cpp
+++ b/tests/unit/test_dbc_parser.cpp
@@ -135,23 +135,6 @@ TEST_F(DBCParserTest, GetSignalNames) {
     EXPECT_EQ(signals.size(), 0);
 }
 
-// Test finding message ID by signal name
-TEST_F(DBCParserTest, GetMessageIdForSignal) {
-    DBCParser parser(test_dbc_file);
-    ASSERT_TRUE(parser.parse());
-    
-    auto msg_id = parser.get_message_id_for_signal("Speed");
-    ASSERT_TRUE(msg_id.has_value());
-    EXPECT_EQ(msg_id.value(), 256);
-    
-    msg_id = parser.get_message_id_for_signal("Voltage");
-    ASSERT_TRUE(msg_id.has_value());
-    EXPECT_EQ(msg_id.value(), 512);
-    
-    msg_id = parser.get_message_id_for_signal("NonExistentSignal");
-    EXPECT_FALSE(msg_id.has_value());
-}
-
 // Test decoding CAN frame with decode_message
 TEST_F(DBCParserTest, DecodeMessage) {
     DBCParser parser(test_dbc_file);
@@ -465,28 +448,6 @@ TEST_F(DBCParserTest, SameSignalInDifferentMessages) {
     std::remove(dbc_file.c_str());
 }
 
-// Test get_message_for_signal method
-TEST_F(DBCParserTest, GetMessageForSignal) {
-    DBCParser parser(test_dbc_file);
-    ASSERT_TRUE(parser.parse());
-    
-    // Test existing signal
-    const auto* msg = parser.get_message_for_signal("Speed");
-    ASSERT_NE(msg, nullptr);
-    EXPECT_EQ(msg->Name(), "TestMessage1");
-    EXPECT_EQ(msg->Id(), 256);
-    
-    // Test another signal
-    msg = parser.get_message_for_signal("Voltage");
-    ASSERT_NE(msg, nullptr);
-    EXPECT_EQ(msg->Name(), "TestMessage2");
-    EXPECT_EQ(msg->Id(), 512);
-    
-    // Test non-existent signal
-    msg = parser.get_message_for_signal("NonExistentSignal");
-    EXPECT_EQ(msg, nullptr);
-}
-
 // Test get_message_id_for_signal with message name
 TEST_F(DBCParserTest, GetMessageIdForSignalWithMessageName) {
     DBCParser parser(test_dbc_file);
@@ -515,19 +476,15 @@ TEST_F(DBCParserTest, GetMessageIdForSignalWithDuplicateNames) {
     auto dbc_file = CreateDBCFileWithSameSignal();
     DBCParser parser(dbc_file);
     ASSERT_TRUE(parser.parse());
-    
-    // Test same signal name in different messages
+
+    // Test same signal name in different messages — disambiguated by message name
     auto msg_id = parser.get_message_id_for_signal("TestMessage4", "TotalFuelUsed");
     ASSERT_TRUE(msg_id.has_value());
     EXPECT_EQ(msg_id.value(), 256);
-    
+
     msg_id = parser.get_message_id_for_signal("TestMessage5", "TotalFuelUsed");
     ASSERT_TRUE(msg_id.has_value());
     EXPECT_EQ(msg_id.value(), 512);
-    
-    // Without message name, should return first found
-    msg_id = parser.get_message_id_for_signal("TotalFuelUsed");
-    ASSERT_TRUE(msg_id.has_value());
 
     // Clean up
     std::remove(dbc_file.c_str());

--- a/tests/unit/test_dbc_parser.cpp
+++ b/tests/unit/test_dbc_parser.cpp
@@ -66,6 +66,27 @@ protected:
         
         file.close();
     }
+
+    std::string CreateDBCFileWithSameSignal() {
+        std::string test_file = "test_extended.dbc";
+        std::ofstream file(test_file);
+        file << "VERSION \"\"\n\n";
+        file << "BS_:\n\n";
+        file << "BU_: ECU1 ECU2 EC3\n\n";
+
+        // Message with ID 0x100 (256)
+        file << "BO_ 256 TestMessage4: 8 ECU2\n";
+        file << " SG_ TotalFuelUsed : 0|32@1+ (0.5,0) [0|2105540607.5] \"L\" ECU1\n";
+        file << "\n";
+
+        // Message with ID 0x200 (512)
+        file << "BO_ 512 TestMessage5: 8 ECU3\n";
+        file << " SG_ TotalFuelUsed : 0|32@1+ (0.5,0) [0|2105540607.5] \"kg\" ECU1\n";
+        file << "\n";
+
+        file.close();
+        return test_file;
+    }
 };
 
 // Test parsing a valid DBC file
@@ -199,6 +220,8 @@ TEST_F(DBCParserTest, DecodeMessageAsUpdates) {
     ASSERT_TRUE(std::holds_alternative<double>(speed_it->value));
     EXPECT_NEAR(std::get<double>(speed_it->value), 100.0, 0.1);
     EXPECT_EQ(speed_it->status, vss::types::SignalQuality::VALID);
+    EXPECT_EQ(speed_it->dbc_signal_name, "Speed");
+    EXPECT_EQ(speed_it->dbc_message_name, "TestMessage1");
 }
 
 // Test decoding with invalid message ID
@@ -407,4 +430,105 @@ TEST_F(DBCParserTest, VariousBitSizePatterns) {
     
     // Clean up
     std::remove("test_extended.dbc");
+}
+
+
+// Test file with same named signals in different messages
+TEST_F(DBCParserTest, SameSignalInDifferentMessages) {
+    auto dbc_file = CreateDBCFileWithSameSignal();
+    DBCParser parser(dbc_file);
+    ASSERT_TRUE(parser.parse());
+
+    auto signals = parser.get_signal_names(256);
+    EXPECT_EQ(signals.size(), 1); // 1 or 2?
+    
+    // Check that specific signals exist
+    ASSERT_TRUE(parser.has_message(256));
+    ASSERT_TRUE(parser.has_message(512));
+
+    EXPECT_NE(std::find(signals.begin(), signals.end(), "TotalFuelUsed"), signals.end());
+
+    std::vector<uint8_t> data = {
+        0x03, 0x00, 0x00, 0x00,  // Total fuel: 1.5
+        0x00, 0x00, 0x00, 0x00
+    };
+
+    auto decoded_signals = parser.decode_message(256, data.data(), data.size());
+    ASSERT_NE(decoded_signals.find("TotalFuelUsed"), decoded_signals.end());
+    EXPECT_EQ(decoded_signals["TotalFuelUsed"].as_double(), 1.5);
+
+    decoded_signals = parser.decode_message(512, data.data(), data.size());
+    ASSERT_NE(decoded_signals.find("TotalFuelUsed"), decoded_signals.end());
+    EXPECT_EQ(decoded_signals["TotalFuelUsed"].as_double(), 1.5);
+
+    // Clean up
+    std::remove(dbc_file.c_str());
+}
+
+// Test get_message_for_signal method
+TEST_F(DBCParserTest, GetMessageForSignal) {
+    DBCParser parser(test_dbc_file);
+    ASSERT_TRUE(parser.parse());
+    
+    // Test existing signal
+    const auto* msg = parser.get_message_for_signal("Speed");
+    ASSERT_NE(msg, nullptr);
+    EXPECT_EQ(msg->Name(), "TestMessage1");
+    EXPECT_EQ(msg->Id(), 256);
+    
+    // Test another signal
+    msg = parser.get_message_for_signal("Voltage");
+    ASSERT_NE(msg, nullptr);
+    EXPECT_EQ(msg->Name(), "TestMessage2");
+    EXPECT_EQ(msg->Id(), 512);
+    
+    // Test non-existent signal
+    msg = parser.get_message_for_signal("NonExistentSignal");
+    EXPECT_EQ(msg, nullptr);
+}
+
+// Test get_message_id_for_signal with message name
+TEST_F(DBCParserTest, GetMessageIdForSignalWithMessageName) {
+    DBCParser parser(test_dbc_file);
+    ASSERT_TRUE(parser.parse());
+    
+    // Test existing signal in specific message
+    auto msg_id = parser.get_message_id_for_signal("TestMessage1", "Speed");
+    ASSERT_TRUE(msg_id.has_value());
+    EXPECT_EQ(msg_id.value(), 256);
+    
+    // Test signal in wrong message
+    msg_id = parser.get_message_id_for_signal("TestMessage2", "Speed");
+    EXPECT_FALSE(msg_id.has_value());
+    
+    // Test non-existent message
+    msg_id = parser.get_message_id_for_signal("NonExistentMessage", "Speed");
+    EXPECT_FALSE(msg_id.has_value());
+    
+    // Test non-existent signal
+    msg_id = parser.get_message_id_for_signal("TestMessage1", "NonExistentSignal");
+    EXPECT_FALSE(msg_id.has_value());
+}
+
+// Test get_message_id_for_signal with same signal names in different messages
+TEST_F(DBCParserTest, GetMessageIdForSignalWithDuplicateNames) {
+    auto dbc_file = CreateDBCFileWithSameSignal();
+    DBCParser parser(dbc_file);
+    ASSERT_TRUE(parser.parse());
+    
+    // Test same signal name in different messages
+    auto msg_id = parser.get_message_id_for_signal("TestMessage4", "TotalFuelUsed");
+    ASSERT_TRUE(msg_id.has_value());
+    EXPECT_EQ(msg_id.value(), 256);
+    
+    msg_id = parser.get_message_id_for_signal("TestMessage5", "TotalFuelUsed");
+    ASSERT_TRUE(msg_id.has_value());
+    EXPECT_EQ(msg_id.value(), 512);
+    
+    // Without message name, should return first found
+    msg_id = parser.get_message_id_for_signal("TotalFuelUsed");
+    ASSERT_TRUE(msg_id.has_value());
+
+    // Clean up
+    std::remove(dbc_file.c_str());
 }


### PR DESCRIPTION
Some manufacturers have named signals the same in multiple messages, e.g. some ECUs rebroadcast some data, or a dbc can span multiple generations and a message could have a new name/source.

This PR adds the ability to specify source as dbc, message_name.signal_name to uniquely point out the signal.