### PR TITLE
Add handling of bool type and unify handling of lua value extraction

### DIFF
--- a/src/lua_mapper.cpp
+++ b/src/lua_mapper.cpp
@@ -153,9 +153,15 @@ VSSSignal LuaMapper::extract_vss_signal(int index) {
 
     // Get value and convert to appropriate VSS Value type based on enum
     lua_getfield(L_, index, "value");
-    if (lua_type(L_, -1) == LUA_TNUMBER) {
+    int lua_value_type = lua_type(L_, -1);
+    if (lua_value_type == LUA_TNUMBER) {
         // Use the ValueType enum to determine the correct C++ type
         switch (value_type) {
+            case ValueType::BOOL:
+                // Boolean stored as number in Lua (1=true, 0=false) - convert back
+                LOG(INFO) << "[extract_vss_signal] Converting Lua number to C++ bool (number value: " << lua_tonumber(L_, -1) << ")";
+                signal.qualified_value.value = static_cast<bool>(lua_tointeger(L_, -1) != 0);
+                break;
             case ValueType::FLOAT:
                 signal.qualified_value.value = static_cast<float>(lua_tonumber(L_, -1));
                 break;
@@ -191,11 +197,11 @@ VSSSignal LuaMapper::extract_vss_signal(int index) {
                 signal.qualified_value.value = lua_tonumber(L_, -1);
                 break;
         }
-    } else if (lua_type(L_, -1) == LUA_TBOOLEAN) {
+    } else if (lua_value_type == LUA_TBOOLEAN) {
         signal.qualified_value.value = static_cast<bool>(lua_toboolean(L_, -1));
-    } else if (lua_type(L_, -1) == LUA_TSTRING) {
+    } else if (lua_value_type == LUA_TSTRING) {
         signal.qualified_value.value = std::string(lua_tostring(L_, -1));
-    } else if (lua_type(L_, -1) == LUA_TTABLE) {
+    } else if (lua_value_type == LUA_TTABLE) {
         // Handle struct values (Lua tables)
         if (value_type == ValueType::STRUCT || value_type == ValueType::STRUCT_ARRAY) {
             // Convert Lua table to VSS struct with proper type handling
@@ -204,7 +210,7 @@ VSSSignal LuaMapper::extract_vss_signal(int index) {
             // Unknown table type, use empty monostate
             signal.qualified_value.value = std::monostate{};
         }
-    } else if (lua_type(L_, -1) == LUA_TNIL) {
+    } else if (lua_value_type == LUA_TNIL) {
         // For nil values, use empty monostate
         signal.qualified_value.value = std::monostate{};
     }
@@ -364,7 +370,7 @@ std::optional<VSSSignal> LuaMapper::extract_vss_signal_from_stack() {
         signal.qualified_value.value = static_cast<bool>(lua_toboolean(L_, -1));
     } else if (lua_value_type == LUA_TSTRING) {
         signal.qualified_value.value = std::string(lua_tostring(L_, -1));
-    } else if (lua_type(L_, -1) == LUA_TTABLE) {
+    } else if (lua_value_type == LUA_TTABLE) {
         // Handle struct values (Lua tables)
         if (value_type == ValueType::STRUCT || value_type == ValueType::STRUCT_ARRAY) {
             // Convert Lua table to VSS struct with proper type handling
@@ -373,7 +379,7 @@ std::optional<VSSSignal> LuaMapper::extract_vss_signal_from_stack() {
             // Unknown table type, use empty monostate
             signal.qualified_value.value = std::monostate{};
         }
-    } else if (lua_type(L_, -1) == LUA_TNIL) {
+    } else if (lua_value_type == LUA_TNIL) {
         // For nil values, use empty monostate
         signal.qualified_value.value = std::monostate{};
     }

--- a/tests/unit/test_lua_mapper_simple.cpp
+++ b/tests/unit/test_lua_mapper_simple.cpp
@@ -163,3 +163,140 @@ TEST_F(LuaMapperSimpleTest, TableReturnValues) {
     EXPECT_TRUE(result->find("42") != std::string::npos || 
                 result->find("table") != std::string::npos);
 }
+
+TEST_F(LuaMapperSimpleTest, BoolFromLuaNumber_True) {
+    std::string code = R"(
+        function map_signals()
+            vss_signals = {}
+            table.insert(vss_signals, {
+                path = "Vehicle.IsMoving",
+                type = 2,  -- ValueType::BOOL
+                value = 1,  -- Lua number representing true
+                status = 0  -- VALID
+            })
+        end
+    )";
+    
+    ASSERT_TRUE(mapper->execute_lua_string(code));
+    auto signals = mapper->map_can_signals({});
+    
+    ASSERT_EQ(signals.size(), 1);
+    EXPECT_EQ(signals[0].path, "Vehicle.IsMoving");
+    EXPECT_TRUE(std::holds_alternative<bool>(signals[0].qualified_value.value));
+    EXPECT_TRUE(std::get<bool>(signals[0].qualified_value.value));
+}
+
+TEST_F(LuaMapperSimpleTest, BoolFromLuaNumber_False) {
+    std::string code = R"(
+        function map_signals()
+            vss_signals = {}
+            table.insert(vss_signals, {
+                path = "Vehicle.IsMoving",
+                type = 2,  -- ValueType::BOOL
+                value = 0,  -- Lua number representing false
+                status = 0
+            })
+        end
+    )";
+    
+    ASSERT_TRUE(mapper->execute_lua_string(code));
+    auto signals = mapper->map_can_signals({});
+    
+    ASSERT_EQ(signals.size(), 1);
+    EXPECT_TRUE(std::holds_alternative<bool>(signals[0].qualified_value.value));
+    EXPECT_FALSE(std::get<bool>(signals[0].qualified_value.value));
+}
+
+TEST_F(LuaMapperSimpleTest, BoolFromLuaBoolean) {
+    std::string code = R"(
+        function map_signals()
+            vss_signals = {}
+            table.insert(vss_signals, {
+                path = "Vehicle.IsMoving",
+                type = 2,  -- ValueType::BOOL
+                value = true,  -- Native Lua boolean
+                status = 0
+            })
+        end
+    )";
+    
+    ASSERT_TRUE(mapper->execute_lua_string(code));
+    auto signals = mapper->map_can_signals({});
+    
+    ASSERT_EQ(signals.size(), 1);
+    EXPECT_TRUE(std::holds_alternative<bool>(signals[0].qualified_value.value));
+    EXPECT_TRUE(std::get<bool>(signals[0].qualified_value.value));
+}
+
+TEST_F(LuaMapperSimpleTest, NonZeroNumberConvertsToTrue) {
+    std::string code = R"(
+        function map_signals()
+            vss_signals = {}
+            table.insert(vss_signals, {
+                path = "Vehicle.IsMoving",
+                type = 2,  -- ValueType::BOOL
+                value = 42,  -- Non-zero should convert to true
+                status = 0
+            })
+        end
+    )";
+    
+    ASSERT_TRUE(mapper->execute_lua_string(code));
+    auto signals = mapper->map_can_signals({});
+    
+    ASSERT_EQ(signals.size(), 1);
+    EXPECT_TRUE(std::holds_alternative<bool>(signals[0].qualified_value.value));
+    EXPECT_TRUE(std::get<bool>(signals[0].qualified_value.value));
+}
+
+TEST_F(LuaMapperSimpleTest, MixedTypes) {
+    std::string code = R"(
+        function map_signals()
+            vss_signals = {}
+            table.insert(vss_signals, {
+                path = "Vehicle.IsMoving",
+                type = 2,  -- BOOL
+                value = 1,
+                status = 0
+            })
+            table.insert(vss_signals, {
+                path = "Vehicle.Speed",
+                type = 12,  -- DOUBLE
+                value = 88.5,
+                status = 0
+            })
+            table.insert(vss_signals, {
+                path = "Vehicle.Gear",
+                type = 5,  -- INT32
+                value = 4,
+                status = 0
+            })
+        end
+    )";
+    
+    ASSERT_TRUE(mapper->execute_lua_string(code));
+    auto signals = mapper->map_can_signals({});
+    
+    ASSERT_EQ(signals.size(), 3);
+    
+    // Check bool
+    auto bool_sig = std::find_if(signals.begin(), signals.end(),
+        [](const VSSSignal& s) { return s.path == "Vehicle.IsMoving"; });
+    ASSERT_NE(bool_sig, signals.end());
+    EXPECT_TRUE(std::holds_alternative<bool>(bool_sig->qualified_value.value));
+    EXPECT_TRUE(std::get<bool>(bool_sig->qualified_value.value));
+    
+    // Check double
+    auto double_sig = std::find_if(signals.begin(), signals.end(),
+        [](const VSSSignal& s) { return s.path == "Vehicle.Speed"; });
+    ASSERT_NE(double_sig, signals.end());
+    EXPECT_TRUE(std::holds_alternative<double>(double_sig->qualified_value.value));
+    EXPECT_DOUBLE_EQ(std::get<double>(double_sig->qualified_value.value), 88.5);
+    
+    // Check int32
+    auto int_sig = std::find_if(signals.begin(), signals.end(),
+        [](const VSSSignal& s) { return s.path == "Vehicle.Gear"; });
+    ASSERT_NE(int_sig, signals.end());
+    EXPECT_TRUE(std::holds_alternative<int32_t>(int_sig->qualified_value.value));
+    EXPECT_EQ(std::get<int32_t>(int_sig->qualified_value.value), 4);
+}


### PR DESCRIPTION
Extracting Lua values were done differently in two different locations. This is now harmonised.

Build failing due to changes in Open1722: https://github.com/COVESA/Open1722/issues/115